### PR TITLE
chore: Marketplace公開用にchat-paritipantタグの定義

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "AI",
     "Chat"
   ],
+  "keywords": [
+    "ai",
+    "chat-participant",
+    "copilot"
+  ],
   "activationEvents": [],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
Visual Studio Code公式において、Chat Participant を定義するExtensionは、`chat-participant` タグを付与すべきと読み解ける記載がある。

> These are some examples of extensions in the Visual Studio Marketplace that contribute a chat participant to the Chat view in VS Code.
> Go to the [Marketplace](https://marketplace.visualstudio.com/search?term=tag%3Achat-participant&target=VSCode&category=All%20categories&sortBy=Relevance) or use the integrated [Extensions view](https://code.visualstudio.com/docs/editor/extension-marketplace) and search for more extensions by using the chat-participant tag.

[Extension Manifest](https://code.visualstudio.com/api/references/extension-manifest)においてタグは`keywords`要素で表現されるため、package.jsonに当該要素を追加し、`chat-participant`タグその他を定義した。
