### PR TITLE
ci: package*.json変更時のみライセンスチェックを行う

### DIFF
--- a/.github/workflows/license_check.yaml
+++ b/.github/workflows/license_check.yaml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
   pull_request:
     branches:
       - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   build:


### PR DESCRIPTION
前提として Promptisでは、`license_check.yaml`で定義されるGitHub Actionsにより、利用ライブラリのライセンスチェックを行っている。

本チェックが必要なのは利用ライブラリが変更された場合であり、それは`pacakge.json`あるいは`package-lock.json`が変更された時であるため、当該条件でのみ当該GitHub Actionsが実行されるように、Action実行のトリガを修正した。