### PR TITLE
devcontainerが起動できるようにする

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,15 +3,15 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:20
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-    libnss3=2:3.87.1-1 \
-    libdbus-1-3=1.14.10-1~deb12u1 \
-    libatk1.0-0=2.46.0-5 \
-    libatk-bridge2.0-0=2.46.0-5 \
-    libgtk-3-0=3.24.38-2~deb12u2 \
-    libgbm1=22.3.6-1+deb12u1 \
-    libasound2=1.2.8-1+b1 \
-    xvfb=2:21.1.7-3+deb12u7 \
-    xauth=1:1.1.2-1 \
+    libnss3 \
+    libdbus-1-3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libgtk-3-0 \
+    libgbm1 \
+    libasound2 \
+    xvfb \
+    xauth \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "Node.js Dev Container",
     "features": {
         "ghcr.io/devcontainers/features/java:1": {
-            "version": "22",
+            "version": "17",
             "installMaven": true
         }
     },

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,25 @@ jobs:
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
 
+    - name: Generate coverage badge
+      uses: jaywcjlove/coverage-badges-cli@main
+      with:
+        source: coverage/coverage-summary.json
+        output: coverage/badge.svg
+
+    - name: Convert SVG to PNG
+      uses: joergnapp/convert-svg-to-png@v1.0
+      with:
+        svgpath: 'coverage/'
+        pngpath: 'coverage/'
+
+    - name: Push coverage badge
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coverage
+        destination_dir: coverage
+
     - name: Build
       run: npm run build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,22 +29,3 @@ jobs:
     - name: Run Tests
       run: npm run test
       if: runner.os == 'Linux'
-
-    - name: Generate coverage badge
-      uses: jaywcjlove/coverage-badges-cli@main
-      with:
-        source: coverage/coverage-summary.json
-        output: coverage/badge.svg
-
-    - name: Convert SVG to PNG
-      uses: joergnapp/convert-svg-to-png@v1.0
-      with:
-        svgpath: 'coverage/'
-        pngpath: 'coverage/'
-
-    - name: Push coverage badge
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./coverage
-        destination_dir: coverage


### PR DESCRIPTION
# 問題

VS Code上でdevcontainerが起動できない。
原因となっていたのは以下の点

1. apt-getでversion pinを指定していたが、一部パッケージに対してpinningしていたバージョンがリポジトリからなくなった
    ```text
    #0 2.904 Package libgtk-3-0 is not available, but is referred to by another package.
    #0 2.904 This may mean that the package is missing, has been obsoleted, or
    #0 2.904 is only available from another source
    #0 2.904 
    #0 2.904 Package xvfb is not available, but is referred to by another package.
    #0 2.904 This may mean that the package is missing, has been obsoleted, or
    #0 2.904 is only available from another source
    #0 2.904 
    #0 2.911 E: Version '3.24.38-2~deb12u2' for 'libgtk-3-0' was not found
    #0 2.911 E: Version '2:21.1.7-3+deb12u7' for 'xvfb' was not found
    ```
2. [feature/java](https://github.com/devcontainers/features/pkgs/container/features%2Fjava)を利用しており、Javaのバージョンとして22を指定したが、当該バージョンはfeature/javaでサポートされていない

# 対応

1. version pinningの削除
    - apt-getのversion pinningは[ベストプラクティスとして知られている](https://github.com/hadolint/hadolint/wiki/DL3008)が、今回ビルドエラーに至ったように、リポジトリからの削除等に対応するメンテナンスが必要になる。メンテ負荷の大きさに対して、devcontainer用のDockerfile中のapt-getのversion pinningによる再現性のメリットは小さい
2. Javaバージョンの修正
    - 現時点のfeature/javaでサポートされているJavaバージョンは17であったため、ここでは17を利用することとした