### PR TITLE
feat: プロンプト適用結果ファイルを1回のPromptis実行で1ファイルに集約する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "20.x",
         "@types/proxyquire": "^1.3.31",
         "@types/sinon": "^17.0.3",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "^1.93.0",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@typescript-eslint/parser": "^8.3.0",
         "@vscode/test-cli": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@types/node": "20.x",
     "@types/proxyquire": "^1.3.31",
     "@types/sinon": "^17.0.3",
-    "@types/vscode": "^1.96.0",
+    "@types/vscode": "^1.93.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "@vscode/test-cli": "^0.0.10",

--- a/src/chatHandler.ts
+++ b/src/chatHandler.ts
@@ -211,8 +211,16 @@ export async function processContent(
 
     try {
       stream.markdown(`## Review Details \n\n`);
-      stream.markdown(`- Prompt: ${path.basename(promptFile)}\n`);
-      stream.markdown(`- Target: ${path.basename(contentFilePath)}\n`);
+
+      // Workspaceのroot pathから相対パスで出力
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (workspaceRoot) {
+        stream.markdown(`- Prompt: ${path.relative(workspaceRoot, promptFile)}\n`);
+        stream.markdown(`- Target: ${path.relative(workspaceRoot, contentFilePath)}\n`);
+      } else {
+        stream.markdown(`- Prompt: ${promptFile}\n`);
+        stream.markdown(`- Target: ${contentFilePath}\n`);
+      }
       stream.markdown(`----\n`);
 
       // プロンプトを送信し、GitHub Copilot の AI モデルから応答を受信、出力する


### PR DESCRIPTION
#22 への対応

1回のPromptis実行で、結果ファイルを1つに集約するようにした

# As-Is

#22の通り、プロンプト適用結果のファイルは次の単位で出力される

- プロンプトファイル別
- かつ、プロンプト適用ファイル別

# To-Be

`@promptis` を呼び出す単位で、プロンプト適用結果ファイルを出力する。したがって、プロンプトファイルの数や適用ファイル数によらず1ファイルに出力する。

# 結果

以下が集約した結果ファイルです。
4つのファイル、複数のプロンプトに対して、結果が以下の通り1つに集約されるようになりました。

<details>
<summary>実際に出力されたファイル</summary>
You specified `#dir`, so the following files under the specified directory `/Users/kiririmode/src/github.com/kiririmode/gitlab-list-comments/src` will be added as targets for prompt application.

- src/notes.graphql
- src/index.ts
- src/merge-requests.graphql
- src/generated/graphql.ts
----

progress: 1/4
----
## Review Details 

- Prompt: 01_readability.md
- Target: notes.graphql
----
以下の理由で新規開発者が読み解くのが難しいと判断しました：

1. クエリの構造が複雑であり、各フィールドの意味が直感的に理解しにくい。
2. コメントがないため、各フィールドの役割や意図が不明確。

以下に、コメントを追加してコードの読みやすさを向上させる具体的な対案を示します。

```graphql
query mergeRequestComments(
  $mergeRequestId: MergeRequestID!
  $discussionAfter: String
) {
  mergeRequest(id: $mergeRequestId) {
    title  # マージリクエストのタイトル
    createdAt  # マージリクエストの作成日時
    mergedAt  # マージリクエストのマージ日時
    author {
      id  # 作成者のID
      name  # 作成者の名前
    }
    approvedBy(first: 100) {
      edges {
        node {
          id  # 承認者のID
          name  # 承認者の名前
        }
      }
    }
    discussions(first: 100, after: $discussionAfter) {
      edges {
        node {
          notes {
            nodes {
              id  # コメントのID
              system  # システムコメントかどうか
              author {
                id  # コメント作成者のID
                name  # コメント作成者の名前
              }
              body  # コメントの内容
              url  # コメントのURL
            }
          }
        }
      }
      pageInfo {
        endCursor  # 次のページのカーソル
        hasNextPage  # 次のページがあるかどうか
      }
    }
  }
}
```

このようにコメントを追加することで、各フィールドの役割が明確になり、新規開発者がコードを理解しやすくなります。

## Review Details 

- Prompt: 02_source_comments.md
- Target: notes.graphql
----
```diff
+ /**
+  * 指定されたマージリクエストIDに関連するコメントを取得するクエリ。
+  * @param {MergeRequestID} $mergeRequestId - マージリクエストのID
+  * @param {String} $discussionAfter - ページネーションのためのカーソル
+  * @returns {Object} マージリクエストの詳細とコメント
+  */
query mergeRequestComments(
  $mergeRequestId: MergeRequestID!
  $discussionAfter: String
) {
  mergeRequest(id: $mergeRequestId) {
    title
    createdAt
    mergedAt
    author {
      id
      name
    }
    approvedBy(first: 100) {
      edges {
        node {
          id
          name
        }
      }
    }
    discussions(first: 100, after: $discussionAfter) {
      edges {
        node {
          notes {
            nodes {
              id
              system
              author {
                id
                name
              }
              body
              url
            }
          }
        }
      }
      pageInfo {
        endCursor
        hasNextPage
      }
    }
  }
}
```

## Review Details 

- Prompt: 01_mermaid_sequence.md
- Target: notes.graphql
----
以下は、指定されたGraphQLクエリの処理フローを表すMermaidのシーケンス図です。

```mermaid
sequenceDiagram
    participant ユーザー
    participant GraphQLサーバー
    participant マージリクエスト
    participant 承認者
    participant ディスカッション
    participant コメント

    ユーザー->>GraphQLサーバー: mergeRequestCommentsクエリを送信
    GraphQLサーバー->>マージリクエスト: マージリクエストIDで検索
    マージリクエスト->>GraphQLサーバー: タイトル、作成日時、マージ日時、著者情報を返す
    GraphQLサーバー->>承認者: 承認者リストを取得
    承認者->>GraphQLサーバー: 承認者情報を返す
    GraphQLサーバー->>ディスカッション: ディスカッションリストを取得
    ディスカッション->>GraphQLサーバー: ディスカッション情報を返す
    GraphQLサーバー->>コメント: コメントリストを取得
    コメント->>GraphQLサーバー: コメント情報を返す
    GraphQLサーバー->>ユーザー: マージリクエストの詳細情報を返す
```

このシーケンス図は、ユーザーがGraphQLサーバーにクエリを送信し、サーバーがマージリクエストの詳細情報を取得して返す流れを示しています。

## Review Details 

- Prompt: 02_mermaid_flowchat.md
- Target: notes.graphql
----
```mermaid
graph TD
    A[mergeRequestId と<br>discussionAfter を<br>受け取る] --> B[mergeRequest を<br>取得する]
    B --> C[タイトル、<br>作成日時、<br>マージ日時を<br>取得する]
    C --> D[著者の<br>ID と名前を<br>取得する]
    D --> E[承認者の<br>ID と名前を<br>取得する]
    E --> F[ディスカッションを<br>取得する]
    F --> G[ノートの<br>ID、システム、<br>著者、本文、<br>URL を取得する]
    G --> H[ページ情報を<br>取得する]
    H --> I{次のページが<br>存在するか}
    I -- いいえ --> J[処理終了]
    I -- はい --> K[次のページの<br>ディスカッションを<br>取得する]
    K --> G
```

progress: 2/4
----
## Review Details 

- Prompt: 01_readability.md
- Target: index.ts
----
以下の理由で新規開発者が読み解くのが難しいと判断しました：

1. コメントが少なく、コードの意図が分かりにくい。
2. ログメッセージが不明瞭で、デバッグが難しい。
3. 変数名が抽象的で、具体的な意味が伝わりにくい。

以下に、コードの読みやすさを向上させるための具体的な対案をunified diffの形で示します。

```diff
--- original.ts
+++ improved.ts
@@ -1,6 +1,7 @@
 import {
   ApolloClient,
   InMemoryCache,
+  ApolloLink,
   HttpLink,
   from,
   ApolloQueryResult,
@@ -16,6 +17,7 @@
 import { Command } from "commander";

 /**
+ * GrqphQL クライアントを作成・返却する
  * @returns {ApolloClient<NormalizedCacheObject>}
  */
 function setupClient(): ApolloClient<NormalizedCacheObject> {
@@ -24,6 +26,7 @@
     uri: "https://gitlab.insidesales-dev.com/api/graphql",
     fetch: fetch,
   });
+  
   const authLink = setContext((_, { headers }) => {
     const accessToken = process.env.GITLAB_ACCESS_TOKEN;
     if (!accessToken) {
@@ -33,6 +36,7 @@
       headers: {
         ...headers,
         Authorization: `Bearer ${accessToken}`,
+        // 認証ヘッダーを設定
       },
     };
   });
@@ -40,6 +44,7 @@
   // エラー処理用のApollo Llink
   const errorLink = onError(({ graphQLErrors, networkError }) => {
     console.log("onError called");
+    // GraphQLエラーのログ出力
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
         console.log(
@@ -48,6 +53,7 @@
           `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
         );
       });
+    // ネットワークエラーのログ出力
     }
     if (networkError) {
       console.log(`[Network error]: ${networkError}`);
@@ -61,6 +67,7 @@
     queryDeduplication: true,
   });
 }

 /**
+ * 対象リポジトリの merge 済 Merge Request の MergeRequestID 一覧を返却する
  * @param {string} repository 対象リポジトリ (例: "eponas/epona")
  * @param {string[]} targetBranches ターゲットブランチ (例: "main")
  * @returns {Promise<string[]>} MergeRequestID リスト
@@ -69,7 +76,7 @@
 async function mergeRequestsIds(
   repository: string,
   targetBranches: string[]
-): Promise<string[]> {
+): Promise<string[]> {
   let hasNextPage: boolean;
   let cursor: string | null | undefined = null;
   const mergeRequestIds: string[] = [];
@@ -77,6 +84,7 @@
   // 対象リポジトリの全 Merge Request を走査するまで繰り返す
   do {
     console.log("Fetching merge request IDs...");
+    // GraphQLクエリを実行してMerge Request IDを取得
     const result: ApolloQueryResult<MergeRequestIdsQuery> = await client.query({
       query: MergeRequestIds,
       variables: {
@@ -86,7 +94,7 @@
         afterMergeRequest: cursor,
       },
     });
-    console.log("mergeRequestId!!");
+    console.log("Fetched merge request IDs.");
     const pageInfo = result.data.project?.mergeRequests?.pageInfo;
     cursor = pageInfo?.endCursor;
     hasNextPage = pageInfo?.hasNextPage ?? false;
@@ -95,6 +103,7 @@
     const idsInPage =
       result.data.project?.mergeRequests?.edges
         ?.map((edge) => edge?.node?.id)
+        // undefinedを除外してIDを配列に追加
         .filter((id): id is string => id !== undefined) ?? [];
     mergeRequestIds.push(...idsInPage);
   } while (hasNextPage);
@@ -105,6 +114,7 @@
 /**
  * 指定した Merge Request に投稿されたコメントの一覧を JSON として出力する
  *
+ * @param {string} mergeRequestId 対象の MergeRequestID
  * @returns {Promise<void>}
  */
 async function notes(mergeRequestId: string): Promise<void> {
@@ -112,6 +122,7 @@
   let cursor: string | null | undefined = null;

   do {
+    // GraphQLクエリを実行してコメントを取得
     const result: ApolloQueryResult<MergeRequestCommentsQuery> =
       await client.query({
         query: MergeRequestComments,
@@ -121,6 +132,7 @@
         },
       });

+    // ページ情報を取得して次のページがあるか確認
     const mergeRequest = result.data.mergeRequest;
     const pageInfo = mergeRequest?.discussions.pageInfo;
     hasNextPage = pageInfo?.hasNextPage ?? false;
@@ -128,6 +140,7 @@
     const approvedBy =
       mergeRequest?.approvedBy?.edges
         ?.map((edge) => edge?.node?.name)
+        // undefinedを除外して承認者名を配列に追加
         .filter((name): name is string => name !== undefined) ?? [];

     mergeRequest?.discussions.edges
@@ -137,6 +150,7 @@
         mergeRequest: mergeRequestId,
         title: mergeRequest.title,
         approvedBy: approvedBy.join("/"),
+        // コメントの詳細情報をJSON形式で出力
         mergeRequestCreatedAt: mergeRequest.createdAt,
         mergeRequestMergedAt: mergeRequest.mergedAt,
         id: note?.id,
@@ -150,6 +164,7 @@
 }

 const client = setupClient();
+// コマンドライン引数を解析してメイン処理を実行
 const main = async () => {
   const program = new Command();
   program
@@ -158,7 +173,7 @@
     .requiredOption("--branch [branches...]", "target branches");
   const opts = program.parse().opts();
   console.log("Starting process...");

-  await (
+  await (
     await mergeRequestsIds(opts.repo, opts.branch)
   ).forEach((id) => notes(id));
 };

 main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
```

## Review Details 

- Prompt: 02_source_comments.md
- Target: index.ts
----
品質の高いソースコメントだった。

## Review Details 

- Prompt: 01_mermaid_sequence.md
- Target: index.ts
----
```mermaid
sequenceDiagram
    participant User
    participant Main
    participant Client
    participant GraphQL
    participant Console

    User->>Main: プログラムを実行
    Main->>Main: コマンドライン引数を解析
    Main->>Client: setupClient() を呼び出し
    Client->>Client: ApolloClient を設定
    Client->>Main: ApolloClient を返却
    Main->>Main: mergeRequestsIds() を呼び出し
    Main->>GraphQL: MergeRequestIds クエリを実行
    GraphQL-->>Main: クエリ結果を返却
    Main->>Main: MergeRequestID リストを蓄積
    Main->>Main: notes() を呼び出し
    Main->>GraphQL: MergeRequestComments クエリを実行
    GraphQL-->>Main: クエリ結果を返却
    Main->>Console: コメント情報を JSON 形式で出力
    Main->>Main: 次の MergeRequestID について notes() を繰り返し呼び出し
    Main->>Console: エラーハンドリング
```

## Review Details 

- Prompt: 02_mermaid_flowchat.md
- Target: index.ts
----
```mermaid
graph TD
    A[GraphQL クライアントを<br>作成・返却する] --> B[コマンドライン<br>オプションを<br>解析する]
    B --> C[対象リポジトリの<br>Merge Request ID<br>一覧を取得する]
    C --> D[Merge Request ID<br>ごとにコメントを<br>取得する]
    D --> E[コメントを<br>JSON として<br>出力する]
    E --> F[処理結果を<br>表示する]
```

progress: 3/4
----
## Review Details 

- Prompt: 01_readability.md
- Target: merge-requests.graphql
----
以下の理由で新規開発者が読み解くのが難しいと判断しました：

1. クエリの意図が明確でない。
2. コメントがないため、各フィールドの意味が分かりにくい。

以下に、コメントを追加してコードの読みやすさを向上させた対案を示します。

```graphql
query mergeRequestIds(
  $fullPath: ID!
  $targetBranches: [String!]
  $afterMergeRequest: String
) {
  project(fullPath: $fullPath) {
    id
    mergeRequests(
      state: merged
      targetBranches: $targetBranches
      after: $afterMergeRequest
    ) {
      pageInfo {
        endCursor
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

```diff
 query mergeRequestIds(
   $fullPath: ID!
   $targetBranches: [String!]
   $afterMergeRequest: String
 ) {
   project(fullPath: $fullPath) {
     id
     mergeRequests(
       state: merged
       targetBranches: $targetBranches
       after: $afterMergeRequest
     ) {
+      # ページ情報を取得
       pageInfo {
         endCursor
         hasNextPage
       }
       edges {
         node {
+          # マージリクエストのIDを取得
           id
         }
       }
     }
   }
 }
```

## Review Details 

- Prompt: 02_source_comments.md
- Target: merge-requests.graphql
----
```diff
+ /**
+  * 指定されたプロジェクトのマージリクエストIDを取得するクエリ
+  * @param {ID!} $fullPath - プロジェクトのフルパス
+  * @param {[String!]} $targetBranches - ターゲットブランチのリスト
+  * @param {String} $afterMergeRequest - ページネーション用のカーソル
+  * @returns {Object} - マージリクエストIDのリストとページ情報
+  */
query mergeRequestIds(
  $fullPath: ID!
  $targetBranches: [String!]
  $afterMergeRequest: String
) {
  project(fullPath: $fullPath) {
    id
    mergeRequests(
      state: merged
      targetBranches: $targetBranches
      after: $afterMergeRequest
    ) {
      pageInfo {
        endCursor
        hasNextPage
      }
      edges {
        node {
          id
        }
      }
    }
  }
}
```

新規開発者が読み解くのが難しいレベルだったため、コメントを追加しました。

## Review Details 

- Prompt: 01_mermaid_sequence.md
- Target: merge-requests.graphql
----
以下は、指定されたGraphQLクエリの処理フローを表すMermaidのシーケンス図です。

```mermaid
sequenceDiagram
    participant ユーザー
    participant GraphQLサーバー
    participant プロジェクト
    participant マージリクエスト

    ユーザー->>GraphQLサーバー: mergeRequestIdsクエリを送信
    GraphQLサーバー->>プロジェクト: プロジェクト情報を取得(fullPath: $fullPath)
    プロジェクト-->>GraphQLサーバー: プロジェクトIDを返す
    GraphQLサーバー->>マージリクエスト: マージリクエストを取得(state: merged, targetBranches: $targetBranches, after: $afterMergeRequest)
    マージリクエスト-->>GraphQLサーバー: マージリクエスト情報を返す
    GraphQLサーバー-->>ユーザー: マージリクエストIDとページ情報を返す
```

## Review Details 

- Prompt: 02_mermaid_flowchat.md
- Target: merge-requests.graphql
----
```mermaid
graph TD
    A[mergeRequestIds<br>クエリの実行] --> B[プロジェクトを<br>取得する]
    B --> C{プロジェクトが<br>見つかるか}
    C -- いいえ --> D[エラー<br>メッセージを<br>返す]
    C -- はい --> E[マージリクエストを<br>取得する]
    E --> F{マージリクエストが<br>見つかるか}
    F -- いいえ --> D
    F -- はい --> G[ページ情報を<br>取得する]
    G --> H{次のページが<br>あるか}
    H -- いいえ --> I[マージリクエストの<br>IDを返す]
    H -- はい --> J[次のページの<br>マージリクエストを<br>取得する]
    J --> G
```

progress: 4/4
----
## Review Details 

- Prompt: 01_readability.md
- Target: graphql.ts
----
Error processing content: Error: Message exceeds token limit.

## Review Details 

- Prompt: 02_source_comments.md
- Target: graphql.ts
----
Error processing content: Error: Message exceeds token limit.

## Review Details 

- Prompt: 01_mermaid_sequence.md
- Target: graphql.ts
----
Error processing content: Error: Message exceeds token limit.

## Review Details 

- Prompt: 02_mermaid_flowchat.md
- Target: graphql.ts
----
Error processing content: Error: Message exceeds token limit.
<details>


