### PR TITLE
fix: reverseEngineeringコマンドが選択肢に表示されない

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -52,12 +52,12 @@ The commands you can instruct are as follows:
 
 ### Command Map
 
-|Command Name|	Execution Content|
+|Command Name| Execution Content|
 |:-|:-|
 |`codereviewCodeStandards` | Conduct a series of code reviews on code standards |
-|`codereviewFunctional`	| Conduct a code review from a functional perspective |
-|`codereviewNonFunctional` |	Conduct a code review from a non-functional perspective |
-|`reverseEngineeringPromptPath` | Conduct reverse engineering on the source code |
+|`codereviewFunctional` | Conduct a code review from a functional perspective |
+|`codereviewNonFunctional` | Conduct a code review from a non-functional perspective |
+|`reverseEngineering` | Conduct reverse engineering on the source code |
 | `drawDiagrams` | Create diagrams from the source code |
 
 For prompt examples, please refer to our [Generative AI Engineering Utilization Guide](https://fintan-contents.github.io/gai-dev-guide/prompts). The compressed files can be downloaded from [here](https://github.com/Fintan-contents/gai-dev-guide/releases).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Chatウィンドウから @promptis に対して指示（コマンド）を出�
 | `codereviewCodeStandards`       | コード基準に関する一連のコードレビューを行う |
 | `codereviewFunctional`          | 機能観点のコードレビューを行う |
 | `codereviewNonFunctional`       | 非機能観点のコードレビューを行う |
-| `reverseEngineeringPromptPath`  | ソースコードに対するリバースエンジニアリングを行う |
+| `reverseEngineering`  | ソースコードに対するリバースエンジニアリングを行う |
 | `drawDiagrams`                  | ソースコードから図式を作成する |
 
 プロンプト例については、[生成AI エンジニアリング活用ガイド](https://fintan-contents.github.io/gai-dev-guide/prompts)にも公開しており、圧縮ファイルは[こちら](https://github.com/Fintan-contents/gai-dev-guide/releases)からダウンロードいただけます。

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
             "description": "Review the Code With Non Functional Requirements"
           },
           {
+            "name": "reverseEngineering",
+            "description": "Reverse Engineer the Code"
+          },
+          {
             "name": "drawDiagrams",
             "description": "Draw Diagrams from the Code"
           }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "vscode": "^1.93.0"
   },
+  "icon": "images/icon_128x128.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/Fintan-contents/promptis/"

--- a/src/chatHandler.ts
+++ b/src/chatHandler.ts
@@ -11,7 +11,7 @@ const commandPromptDirectoryMap: CommandPromptPathMap = new Map([
   ["codereviewCodeStandards", Config.getCodeReviewStandardPath],
   ["codereviewFunctional", Config.getCodeReviewFunctionalPath],
   ["codereviewNonFunctional", Config.getCodeReviewNonFunctionalPath],
-  ["reverseEngineeringPromptPath", Config.getReverseEngineeringPromptPath],
+  ["reverseEngineering", Config.getReverseEngineeringPromptPath],
   ["drawDiagrams", Config.getDrawDiagramsPromptPath],
 ]);
 


### PR DESCRIPTION
# 問題

READMEで謳っている `reverseEngineering` コマンドが、GitHub Copilot Chatのコマンドの選択肢に表示されない。
合わせて、READMEでは `reverseEngineeringPromptPath` というコマンドとして表現していたが、これは誤植であり、本来は `reverseEngineering`が正しい（`PromptPath`はあくまで設定を表現している）。

<img width="550" alt="missing" src="https://github.com/user-attachments/assets/4bed9efa-900a-49db-80db-8e216ea239d3" />

# 原因

@kiririmode-tis の人為的なミスで、対象コマンドを定義する[`contribution.commands`](https://code.visualstudio.com/api/references/contribution-points#contributes.commands)から削除してしまっていたため。

本PRで修正しました。

# 確認事項

- `reverseEngineering` コマンドが補完候補に現れること

<img width="659" alt="補完" src="https://github.com/user-attachments/assets/6395c247-bc3d-43d3-ae35-92fd1702a313" />

- 対象コマンドが実行できること

<img width="646" alt="execution" src="https://github.com/user-attachments/assets/d8141580-843c-44df-8398-3504a08251b3" />

