### PR TITLE
Chatリクエスト単位で言語モデルを選択可能とする

### DIFF
--- a/src/chatHandler.ts
+++ b/src/chatHandler.ts
@@ -171,18 +171,17 @@ export async function processContent(
     ];
 
     try {
-      // チャット内容保存ディレクトリを取得。有効な値が存在している場合は、ファイルに保存するようにする
-      const outputDirPath = Config.getChatOutputDirPath();
-      if (outputDirPath && outputDirPath.length > 0) {
-        // ResponseStream をラップして、ファイルに保存するようにする
-        stream = new FileChatResponseStreamWrapper(
-          stream,
-          makeChatFilePath(outputDirPath),
-        );
-      }
       stream.markdown(`## Review Details \n\n`);
-      stream.markdown(`- Prompt: ${path.basename(promptFile)}\n`);
-      stream.markdown(`- Target: ${path.basename(contentFilePath)}\n`);
+
+      // Workspaceのroot pathから相対パスで出力
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (workspaceRoot) {
+        stream.markdown(`- Prompt: ${path.relative(workspaceRoot, promptFile)}\n`);
+        stream.markdown(`- Target: ${path.relative(workspaceRoot, contentFilePath)}\n`);
+      } else {
+        stream.markdown(`- Prompt: ${promptFile}\n`);
+        stream.markdown(`- Target: ${contentFilePath}\n`);
+      }
       stream.markdown(`----\n`);
 
       // プロンプトを送信し、GitHub Copilot の AI モデルから応答を受信、出力する

--- a/src/test/chatHandler.test.ts
+++ b/src/test/chatHandler.test.ts
@@ -72,7 +72,9 @@ suite("chatHandler Test Suite", function () {
         references: [],
         toolReferences: [],
         toolInvocationToken: {} as never,
-        model: {} as vscode.LanguageModelChat,
+        model: {
+          sendRequest: sinon.stub().resolves({ text: [""] }),
+        } as unknown as vscode.LanguageModelChat,
       };
       const { context, stream, token } = createPartOfChatRequest();
 
@@ -87,7 +89,9 @@ suite("chatHandler Test Suite", function () {
         references: [],
         toolReferences: [],
         toolInvocationToken: {} as never,
-        model: {} as vscode.LanguageModelChat,
+        model: {
+          sendRequest: sinon.stub().resolves({ text: [""] }),
+        } as unknown as vscode.LanguageModelChat,
       };
       const { context, stream, token } = createPartOfChatRequest();
 
@@ -102,7 +106,9 @@ suite("chatHandler Test Suite", function () {
         references: [],
         toolReferences: [],
         toolInvocationToken: {} as never,
-        model: {} as vscode.LanguageModelChat,
+        model: {
+          sendRequest: sinon.stub().resolves({ text: [""] }),
+        } as unknown as vscode.LanguageModelChat,
       };
       const { context, stream, token } = createPartOfChatRequest();
 
@@ -117,7 +123,9 @@ suite("chatHandler Test Suite", function () {
         references: [],
         toolReferences: [],
         toolInvocationToken: {} as never,
-        model: {} as vscode.LanguageModelChat,
+        model: {
+          sendRequest: sinon.stub().resolves({ text: [""] }),
+        } as unknown as vscode.LanguageModelChat,
       };
       const { context, stream, token } = createPartOfChatRequest();
 
@@ -147,7 +155,9 @@ suite("chatHandler Test Suite", function () {
         references: [{ id: "vscode.file", range: [12, 25], value: { $mid: 1, path: __filename, scheme: "file" } }],
         toolReferences: [],
         toolInvocationToken: {} as never,
-        model: {} as vscode.LanguageModelChat,
+        model: {
+          sendRequest: sinon.stub().resolves({ text: [""] }),
+        } as unknown as vscode.LanguageModelChat,
       };
       const { context, stream, token } = createPartOfChatRequest();
 


### PR DESCRIPTION
# 概要

#18 の対応として、これまで、固定で言語モデルを設定していたところを、ユーザが選択した言語モデルを都度設定する形に実装を置き換えています。

Close: #18 

# 確認観点

- [x] `o1-mini (Preview)`、`Claude 3.5 Sonnet (Preview)`をそれぞれ選択して `@promptis` へメンションし、全く違う回答内容が得られた（言語モデルが切り替わっていることが確認できた）こと
- [x] ３世代分でテストを実施し、すべてパスしていること

