### PR TITLE
fix: ファイル参照が正しく処理されない不具合の修正

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -64,7 +64,11 @@ For prompt examples, please refer to our [Generative AI Engineering Utilization 
 
 ### Chat Variables
 
-The [chat variables](https://code.visualstudio.com/docs/copilot/copilot-chat#_chat-context) such as `#file` and `#selection` available in GitHub Copilot Chat can be used as is.  
+Of the [chat contexts](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-chat-context) available in GitHub Copilot Chat, `#<file | folder>` can be used as is.  
+
+> [!NOTE]
+> Although `#file` no longer appears in suggestions, you can still specify files by using the suggestions that appear after typing `#`. Additionally, you can automatically add file references by dragging and dropping files or directories into the Chat window.
+
 In Promptis, you can also use the following chat variables:
 
 | Chat Variable | Description | Example |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Chatウィンドウから @promptis に対して指示（コマンド）を出�
 
 ### チャット変数
 
-GitHub Copilot Chatで利用できる`#file`や`#selection`などの[チャット変数](https://code.visualstudio.com/docs/copilot/copilot-chat#_chat-context)はそのままご利用いただけます。  
+GitHub Copilot Chatで利用できる[チャットコンテキスト](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_add-chat-context)のうち、`#<file | folder>`はそのままご利用いただけます。 
+
+> [!NOTE]
+> VSCode version 1.100以降では、`#file`によるサジェストが表示されなくなりましたが、`#`を入力した後のサジェストを利用することで引き続きファイル指定ができます。また、Chatウィンドウにファイルやディレクトリをドラッグ＆ドロップすることで、自動的にファイル参照を追加することも可能です。
+
 Promptisではさらに、次のチャット変数を利用できます。
 
 | チャット変数 | 説明 | 例 |

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -14,6 +14,9 @@ import { extractFilesInDirectory, findPromptFiles, timestampAsString } from "../
 const fsStub = {
   existsSync: sinon.stub(),
   statSync: sinon.stub(),
+  promises: {
+    stat: sinon.stub(),
+  },
 };
 const { getUserSpecifiedDirectory, extractTargetFiles } = proxyquire("../util", { fs: fsStub });
 
@@ -58,6 +61,7 @@ suite("Util Test Suite", function () {
       mockFindFiles = sinon.stub(vscode.workspace, "findFiles");
       fsStub.existsSync.reset();
       fsStub.statSync.reset();
+      fsStub.promises.stat.reset();
     });
 
     teardown(function () {
@@ -84,9 +88,9 @@ suite("Util Test Suite", function () {
         ],
       } as unknown as vscode.ChatRequest;
 
-      fsStub.statSync.withArgs("/path/to/file1").returns({ isDirectory: () => false });
-      fsStub.statSync.withArgs("/path/to/file2").returns({ isDirectory: () => false });
-      fsStub.statSync.withArgs("/path/to/dir").returns({ isDirectory: () => true });
+      fsStub.promises.stat.withArgs("/path/to/file1").resolves({ isDirectory: () => false });
+      fsStub.promises.stat.withArgs("/path/to/file2").resolves({ isDirectory: () => false });
+      fsStub.promises.stat.withArgs("/path/to/dir").resolves({ isDirectory: () => true });
       mockFindFiles.resolves([vscode.Uri.file("/path/to/dir/file1.md"), vscode.Uri.file("/path/to/dir/file2.md")]);
 
       const stream = { markdown: sinon.stub(), progress: sinon.stub() } as unknown as vscode.ChatResponseStream;
@@ -130,8 +134,8 @@ suite("Util Test Suite", function () {
         ],
       } as unknown as vscode.ChatRequest;
 
-      fsStub.statSync.withArgs("/path/to/file1").returns({ isDirectory: () => false });
-      fsStub.statSync.withArgs("/path/to/file2").returns({ isDirectory: () => false });
+      fsStub.promises.stat.withArgs("/path/to/file1").resolves({ isDirectory: () => false });
+      fsStub.promises.stat.withArgs("/path/to/file2").resolves({ isDirectory: () => false });
       const stream = { markdown: sinon.stub(), progress: sinon.stub() } as unknown as vscode.ChatResponseStream;
 
       const result = await extractTargetFiles(req, stream);

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -79,7 +79,7 @@ suite("Util Test Suite", function () {
       const stream = { markdown: sinon.stub(), progress: sinon.stub() } as unknown as vscode.ChatResponseStream;
 
       const result = await extractTargetFiles(req, stream);
-      assert.deepStrictEqual(result, ["/path/to/file2", "/path/to/file1"]);
+      assert.deepStrictEqual(result, ["/path/to/file1", "/path/to/file2"]);
     });
 
     test("extractTargetFilesが参照なしのケースを処理できるべき", async function () {
@@ -98,19 +98,23 @@ suite("Util Test Suite", function () {
         prompt: "hoge",
         references: [
           {
-            id: "vscode.file",
+            id: "vscode.hoge",
             value: vscode.Uri.file("/path/to/file1"),
           },
           {
-            id: "vscode.other",
+            id: "vscode.fuga",
             value: vscode.Uri.file("/path/to/file2"),
+          },
+          {
+            id: "vscode.piyo",
+            value: "this is string type",
           },
         ],
       } as unknown as vscode.ChatRequest;
       const stream = { markdown: sinon.stub(), progress: sinon.stub() } as unknown as vscode.ChatResponseStream;
 
       const result = await extractTargetFiles(req, stream);
-      assert.deepStrictEqual(result, ["/path/to/file1"]);
+      assert.deepStrictEqual(result, ["/path/to/file1", "/path/to/file2"]);
     });
 
     test("extractTargetFilesが、プロンプトで#dirを指定されたときは指定ディレクトリ配下のファイルも返却すべき", async function () {

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -57,6 +57,7 @@ suite("Util Test Suite", function () {
       mockShowOpenDialog = sinon.stub(vscode.window, "showOpenDialog");
       mockFindFiles = sinon.stub(vscode.workspace, "findFiles");
       fsStub.existsSync.reset();
+      fsStub.statSync.reset();
     });
 
     teardown(function () {

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import proxyquire from "proxyquire";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import { extractFilesInDirectory, findPromptFiles, timestampAsString } from "../util";
+import { extractFilesInDirectory, findPromptFiles, processDirectoryFiles, timestampAsString } from "../util";
 
 /*
  * fs.existsSync のスタブ
@@ -297,6 +297,115 @@ suite("Util Test Suite", function () {
 
       const result = getUserSpecifiedDirectory(req);
       assert.strictEqual(result, undefined);
+    });
+  });
+
+  suite("processDirectoryFiles Test Suite", function () {
+    let mockFindFiles: sinon.SinonStub;
+    let mockMarkdown: sinon.SinonStub;
+    let mockStream: vscode.ChatResponseStream;
+
+    setup(function () {
+      mockFindFiles = sinon.stub(vscode.workspace, "findFiles");
+      mockMarkdown = sinon.stub();
+      mockStream = { markdown: mockMarkdown } as unknown as vscode.ChatResponseStream;
+    });
+
+    teardown(function () {
+      mockFindFiles.restore();
+    });
+
+    test("指定されたディレクトリ内のファイルを正常に処理し、パスを返すべき", async function () {
+      const dirUri = vscode.Uri.file("/path/to/directory");
+      const filterPattern = "**/*.md";
+      const messagePrefix = "Test message";
+
+      mockFindFiles.resolves([
+        vscode.Uri.file("/path/to/directory/file1.md"),
+        vscode.Uri.file("/path/to/directory/subdir/file2.md"),
+      ]);
+
+      const result = await processDirectoryFiles(dirUri, filterPattern, mockStream, messagePrefix);
+
+      assert.deepStrictEqual(result, ["/path/to/directory/file1.md", "/path/to/directory/subdir/file2.md"]);
+
+      sinon.assert.calledThrice(mockMarkdown);
+      sinon.assert.calledWith(mockMarkdown.firstCall, "Test message `/path/to/directory` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(mockMarkdown.secondCall, "- directory/file1.md\n");
+      sinon.assert.calledWith(mockMarkdown.thirdCall, "- directory/subdir/file2.md\n");
+    });
+
+    test("ディレクトリにファイルがない場合、空の配列を返すべき", async function () {
+      const dirUri = vscode.Uri.file("/path/to/empty/directory");
+      const filterPattern = "**/*.md";
+      const messagePrefix = "Empty directory test";
+
+      mockFindFiles.resolves([]);
+
+      const result = await processDirectoryFiles(dirUri, filterPattern, mockStream, messagePrefix);
+
+      assert.deepStrictEqual(result, []);
+      sinon.assert.calledOnce(mockMarkdown);
+      sinon.assert.calledWith(mockMarkdown, "Empty directory test `/path/to/empty/directory` will be added as targets for prompt application.\n\n");
+    });
+
+    test("異なるフィルタパターンで正しくファイルを処理すべき", async function () {
+      const dirUri = vscode.Uri.file("/project/src");
+      const filterPattern = "**/*.{ts,js}";
+      const messagePrefix = "JavaScript/TypeScript files";
+
+      mockFindFiles.resolves([
+        vscode.Uri.file("/project/src/main.ts"),
+        vscode.Uri.file("/project/src/utils/helper.js"),
+      ]);
+
+      const result = await processDirectoryFiles(dirUri, filterPattern, mockStream, messagePrefix);
+
+      assert.deepStrictEqual(result, ["/project/src/main.ts", "/project/src/utils/helper.js"]);
+
+      sinon.assert.calledThrice(mockMarkdown);
+      sinon.assert.calledWith(mockMarkdown.firstCall, "JavaScript/TypeScript files `/project/src` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(mockMarkdown.secondCall, "- src/main.ts\n");
+      sinon.assert.calledWith(mockMarkdown.thirdCall, "- src/utils/helper.js\n");
+    });
+
+    test("相対パス表示が正しく行われるべき", async function () {
+      const dirUri = vscode.Uri.file("/very/long/path/to/project");
+      const filterPattern = "*.md";
+      const messagePrefix = "Markdown files";
+
+      mockFindFiles.resolves([
+        vscode.Uri.file("/very/long/path/to/project/README.md"),
+        vscode.Uri.file("/very/long/path/to/project/CHANGELOG.md"),
+      ]);
+
+      const result = await processDirectoryFiles(dirUri, filterPattern, mockStream, messagePrefix);
+
+      assert.deepStrictEqual(result, [
+        "/very/long/path/to/project/README.md",
+        "/very/long/path/to/project/CHANGELOG.md",
+      ]);
+
+      sinon.assert.calledThrice(mockMarkdown);
+      sinon.assert.calledWith(mockMarkdown.firstCall, "Markdown files `/very/long/path/to/project` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(mockMarkdown.secondCall, "- project/README.md\n");
+      sinon.assert.calledWith(mockMarkdown.thirdCall, "- project/CHANGELOG.md\n");
+    });
+
+    test("単一ファイルの場合も正しく処理すべき", async function () {
+      const dirUri = vscode.Uri.file("/home/user/docs");
+      const filterPattern = "README.md";
+      const messagePrefix = "Single file";
+
+      mockFindFiles.resolves([vscode.Uri.file("/home/user/docs/README.md")]);
+
+      const result = await processDirectoryFiles(dirUri, filterPattern, mockStream, messagePrefix);
+
+      assert.deepStrictEqual(result, ["/home/user/docs/README.md"]);
+
+      sinon.assert.calledTwice(mockMarkdown);
+      sinon.assert.calledWith(mockMarkdown.firstCall, "Single file `/home/user/docs` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(mockMarkdown.secondCall, "- docs/README.md\n");
     });
   });
 });

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -97,10 +97,10 @@ suite("Util Test Suite", function () {
 
       const result = await extractTargetFiles(req, stream);
       assert.deepStrictEqual(result, [
-        "/path/to/file1",
-        "/path/to/file2",
         "/path/to/dir/file1.md",
         "/path/to/dir/file2.md",
+        "/path/to/file2",
+        "/path/to/file1",
       ]);
     });
 
@@ -139,7 +139,7 @@ suite("Util Test Suite", function () {
       const stream = { markdown: sinon.stub(), progress: sinon.stub() } as unknown as vscode.ChatResponseStream;
 
       const result = await extractTargetFiles(req, stream);
-      assert.deepStrictEqual(result, ["/path/to/file1", "/path/to/file2"]);
+      assert.deepStrictEqual(result, ["/path/to/file2", "/path/to/file1"]);
     });
 
     test("extractTargetFilesが、プロンプトで#dirを指定されたときは指定ディレクトリ配下のファイルも返却すべき", async function () {
@@ -330,7 +330,10 @@ suite("Util Test Suite", function () {
       assert.deepStrictEqual(result, ["/path/to/directory/file1.md", "/path/to/directory/subdir/file2.md"]);
 
       sinon.assert.calledThrice(mockMarkdown);
-      sinon.assert.calledWith(mockMarkdown.firstCall, "Test message `/path/to/directory` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(
+        mockMarkdown.firstCall,
+        "Test message `/path/to/directory` will be added as targets for prompt application.\n\n",
+      );
       sinon.assert.calledWith(mockMarkdown.secondCall, "- directory/file1.md\n");
       sinon.assert.calledWith(mockMarkdown.thirdCall, "- directory/subdir/file2.md\n");
     });
@@ -346,7 +349,10 @@ suite("Util Test Suite", function () {
 
       assert.deepStrictEqual(result, []);
       sinon.assert.calledOnce(mockMarkdown);
-      sinon.assert.calledWith(mockMarkdown, "Empty directory test `/path/to/empty/directory` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(
+        mockMarkdown,
+        "Empty directory test `/path/to/empty/directory` will be added as targets for prompt application.\n\n",
+      );
     });
 
     test("異なるフィルタパターンで正しくファイルを処理すべき", async function () {
@@ -364,7 +370,10 @@ suite("Util Test Suite", function () {
       assert.deepStrictEqual(result, ["/project/src/main.ts", "/project/src/utils/helper.js"]);
 
       sinon.assert.calledThrice(mockMarkdown);
-      sinon.assert.calledWith(mockMarkdown.firstCall, "JavaScript/TypeScript files `/project/src` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(
+        mockMarkdown.firstCall,
+        "JavaScript/TypeScript files `/project/src` will be added as targets for prompt application.\n\n",
+      );
       sinon.assert.calledWith(mockMarkdown.secondCall, "- src/main.ts\n");
       sinon.assert.calledWith(mockMarkdown.thirdCall, "- src/utils/helper.js\n");
     });
@@ -387,7 +396,10 @@ suite("Util Test Suite", function () {
       ]);
 
       sinon.assert.calledThrice(mockMarkdown);
-      sinon.assert.calledWith(mockMarkdown.firstCall, "Markdown files `/very/long/path/to/project` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(
+        mockMarkdown.firstCall,
+        "Markdown files `/very/long/path/to/project` will be added as targets for prompt application.\n\n",
+      );
       sinon.assert.calledWith(mockMarkdown.secondCall, "- project/README.md\n");
       sinon.assert.calledWith(mockMarkdown.thirdCall, "- project/CHANGELOG.md\n");
     });
@@ -404,7 +416,10 @@ suite("Util Test Suite", function () {
       assert.deepStrictEqual(result, ["/home/user/docs/README.md"]);
 
       sinon.assert.calledTwice(mockMarkdown);
-      sinon.assert.calledWith(mockMarkdown.firstCall, "Single file `/home/user/docs` will be added as targets for prompt application.\n\n");
+      sinon.assert.calledWith(
+        mockMarkdown.firstCall,
+        "Single file `/home/user/docs` will be added as targets for prompt application.\n\n",
+      );
       sinon.assert.calledWith(mockMarkdown.secondCall, "- docs/README.md\n");
     });
   });

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,7 @@ function uriToPath(uri: vscode.Uri): string {
  * @param {string} messagePrefix - ストリーム出力時のメッセージプレフィックス
  * @returns {Promise<string[]>} - ファイルのパスの配列
  */
-async function processDirectoryFiles(
+export async function processDirectoryFiles(
   dirUri: vscode.Uri,
   filterPattern: string,
   stream: vscode.ChatResponseStream,

--- a/src/util.ts
+++ b/src/util.ts
@@ -152,8 +152,6 @@ export async function extractTargetFiles(
     srcPaths.push(...paths);
   }
 
-  console.info(JSON.stringify(req.references, null, 2));
-
   for (let i = 0; i < req.references.length; i++) {
     const ref = req.references[i];
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -197,7 +197,7 @@ export async function extractTargetFiles(
       }
     }
   }
-  const uniqueSrcPaths = srcPaths.filter((item, index) => srcPaths.indexOf(item) === index);
+  const uniqueSrcPaths = Array.from(new Set(srcPaths));
 
   // 処理対象ファイルを出力し終えたことを示すために、区切り線を表示する
   stream.markdown(`----\n\n`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -169,7 +169,8 @@ export async function extractTargetFiles(
     srcPaths.push(...paths);
   }
 
-  for (let i = 0; i < req.references.length; i++) {
+  // references は出現順の逆順になるため、末尾から処理する
+  for (let i = req.references.length - 1; i >= 0; i--) {
     const ref = req.references[i];
 
     // referenceがファイルの場合、当該ファイルの内容を返す

--- a/src/util.ts
+++ b/src/util.ts
@@ -183,7 +183,8 @@ export async function extractTargetFiles(
       const uri = ref.value as vscode.Uri;
       const filePath = uriToPath(uri);
 
-      if (fs.statSync(filePath).isDirectory()) {
+      const stats = await fs.promises.stat(filePath);
+      if (stats.isDirectory()) {
         const directoryFiles = await processDirectoryFiles(
           uri,
           filterPattern,


### PR DESCRIPTION
closes: #67

# 前提

現在のVS Code は、Chat WindowにディレクトリやファイルをD&Dすることで、それらの内容をコンテキストとして追加することが可能となっている。

<img width="359" alt="スクリーンショット 2025-06-01 1 29 40" src="https://github.com/user-attachments/assets/fdaad026-effe-47ba-8566-e07c7b9584ea" />

# 修正概要

- ChatRequest の references 配列からファイル参照（vscode.Uri 型）をすべて抽出するよう修正
    - 従来は `id` が `vscode.file` 等になっており、promptisでもこれをファイル参照として扱っていたが、vscode 本体側で変更されたため。
    - ディレクトリを指定した場合であっても、このファイル参照として扱われる。
- 参照順序の逆転や重複排除のロジックを整理。これにより #file 指定が正しく動作し、複数ファイルや他種 reference との混在にも対応

# 確認事項

- ファイルをChat WindowにD&Dすることで、対象ファイルがレビュー可能となることを確認
- ファイルをChat Windowに `#` で始める形でファイルを指定することで、対象ファイルがレビュー可能となることを確認
    - `sym` には対応できていないです
- ディレクトリを Chat Window に `#` で始める形で指定することで、対象ディレクトリの配下ファイルすべてがレビュー可能になることを確認
