### PR TITLE
Issue #112 Git差分レビュー機能を追加

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -58,6 +58,7 @@ The commands you can instruct are as follows:
 |`codereviewCodeStandards` | Conduct a series of code reviews on code standards |
 |`codereviewFunctional` | Conduct a code review from a functional perspective |
 |`codereviewNonFunctional` | Conduct a code review from a non-functional perspective |
+|`codereviewDiff` | Conduct a code review only on Git diff content |
 |`reverseEngineering` | Conduct reverse engineering on the source code |
 | `drawDiagrams` | Create diagrams from the source code |
 
@@ -76,6 +77,26 @@ In Promptis, you can also use the following chat variables:
 | ------------- | ----------- | ------- |
 | `#dir:[Directory]` | By including `#dir` in the prompt, you can specify the directory to which the prompt will be applied. The prompt will be executed on all files under the specified directory. You can also directly specify the directory in the format `#dir:path/to/dir`. | `@promptis /codereviewCodeStandards #dir` |
 | `#filter:[GlobPattern]` | By including `#filter:[GlobPattern]` in the prompt, you can narrow down the files extracted by the `#dir` specification to only those that match the GlobPattern. For the patterns that can be specified, refer to [GlobPattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern). | `@promptis /codereviewCodeStandards #dir #filter:**/*.{ts,js}`
+| `#range:[GitRange]` | Specifies the Git diff range used by `/codereviewDiff`. If omitted, Promptis uses `promptis.git.defaultDiffRange`. | `@promptis /codereviewDiff #range:origin/develop...HEAD` |
+
+### Reviewing Git Diff Only
+
+Use `/codereviewDiff` to review Git unified diff content instead of whole files. By default, Promptis reviews `origin/main...HEAD`.
+
+```text
+@promptis /codereviewDiff
+```
+
+You can override the diff range with `#range`.
+
+```text
+@promptis /codereviewDiff #range:origin/develop...HEAD
+@promptis /codereviewDiff #range:HEAD~3..HEAD
+```
+
+Promptis reads diff content through VS Code's built-in Git extension (`vscode.git`) and sends each changed file's unified diff to the existing prompt execution flow. Deleted files are skipped because they have no new side to review.
+
+`/codereviewDiff` uses prompts from `codeReview.diffPath` when configured. If it is not configured, Promptis falls back to `codeReview.codeStandardPath`.
 
 ### Prompt File Front Matter
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Chatウィンドウから @promptis に対して指示（コマンド）を出�
 | `codereviewCodeStandards`       | コード基準に関する一連のコードレビューを行う |
 | `codereviewFunctional`          | 機能観点のコードレビューを行う |
 | `codereviewNonFunctional`       | 非機能観点のコードレビューを行う |
+| `codereviewDiff`                | Git差分のみを対象にコードレビューを行う |
 | `reverseEngineering`  | ソースコードに対するリバースエンジニアリングを行う |
 | `drawDiagrams`                  | ソースコードから図式を作成する |
 
@@ -80,6 +81,26 @@ Promptisではさらに、次のチャット変数を利用できます。
 | ------------ | ---- | -- |
 | `#dir:[Directory]` | プロンプト中に`#dir`を含めることで、プロンプトを適用するディレクトリを指定できる。指定したディレクトリ配下の全ファイルに対してプロンプトが実行される。また、`#dir:path/to/dir`の形式で直接ディレクトリを指定することも可能。 | `@promptis /codereviewCodeStandards #dir` |
 | `#filter:[GlobPattern]` | プロンプト中に`#filter:[GlobPattern]`を含めることで、`#dir`指定によって抽出されたファイルのうち、GlobPatternに合致するもののみを適用対象として絞り込める。指定できるパターンについては[GlobPattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern)を参照。 | `@promptis /codereviewCodeStandards #dir #filter:**/*.{ts,js}`
+| `#range:[GitRange]` | `/codereviewDiff`で使用するGit差分範囲を指定できる。未指定時は`promptis.git.defaultDiffRange`の値を使う。 | `@promptis /codereviewDiff #range:origin/develop...HEAD` |
+
+### Git差分のみをレビューする
+
+`/codereviewDiff`を使うと、ファイル全体ではなくGitのUnified diffのみをレビュー対象にできます。デフォルトでは`origin/main...HEAD`の差分を取得します。
+
+```text
+@promptis /codereviewDiff
+```
+
+差分範囲は`#range`で変更できます。
+
+```text
+@promptis /codereviewDiff #range:origin/develop...HEAD
+@promptis /codereviewDiff #range:HEAD~3..HEAD
+```
+
+PromptisはVS Code標準のGit拡張（`vscode.git`）から差分を取得し、変更ファイルごとのUnified diffを既存のプロンプトに渡します。削除ファイルは新側のレビュー対象が存在しないためスキップされます。
+
+`/codereviewDiff`は、`codeReview.diffPath`が設定されている場合はそのディレクトリのプロンプトを使います。未設定の場合は`codeReview.codeStandardPath`のプロンプトを使います。
 
 ### プロンプトファイルのFront Matter
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
             "description": "Review the Code With Non Functional Requirements"
           },
           {
+            "name": "codereviewDiff",
+            "description": "Review the Git Diff Only"
+          },
+          {
             "name": "reverseEngineering",
             "description": "Reverse Engineer the Code"
           },
@@ -74,15 +78,20 @@
           "description": "Absolute path of the directory storing code review prompts (from a non-functional perspective)",
           "order": 3
         },
+        "codeReview.diffPath": {
+          "type": "string",
+          "description": "Absolute path of the directory storing prompts for Git diff reviews. If omitted, codeReview.codeStandardPath is used.",
+          "order": 4
+        },
         "reverseEngineering.promptsPath": {
           "type": "string",
           "description": "Absolute path of the directory storing prompts for reverse engineering",
-          "order": 4
+          "order": 5
         },
         "drawDiagrams.promptsPath": {
           "type": "string",
           "description": "Absolute path of the directory for prompts used in diagram generation",
-          "order": 5
+          "order": 6
         },
         "prompt.excludeFilePatterns": {
           "type": "array",
@@ -91,18 +100,18 @@
           },
           "default": [],
           "markdownDescription": "Patterns for filenames of prompt files under the prompt storage directory that should not be executed (e.g., **/dir/*.md). Refer to the [minimatch README](https://github.com/isaacs/minimatch) for writable patterns.",
-          "order": 6
+          "order": 7
         },
         "chat.outputPath": {
           "type": "string",
           "description": "Absolute path of the directory for outputting chat content backups",
-          "order": 7
+          "order": 8
         },
         "telemetry.enable": {
           "type": "boolean",
           "description": "Enable telemetry to help improve the extension",
           "default": true,
-          "order": 8
+          "order": 9
         },
         "promptis.output.mode": {
           "type": "string",
@@ -112,7 +121,13 @@
           ],
           "default": "chat-only",
           "description": "Output mode for review results. 'chat-only' shows detailed output in chat window, 'file-only' minimizes chat output and saves detailed results to file.",
-          "order": 9
+          "order": 10
+        },
+        "promptis.git.defaultDiffRange": {
+          "type": "string",
+          "default": "origin/main...HEAD",
+          "description": "Default Git diff range for /codereviewDiff. Examples: origin/main...HEAD, origin/develop...HEAD, HEAD~3..HEAD.",
+          "order": 11
         }
       }
     },

--- a/src/chatHandler.ts
+++ b/src/chatHandler.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { postUsage } from "./api";
 import { FileChatResponseStreamWrapper } from "./chatutil";
 import { Config } from "./config";
+import * as gitDiff from "./gitDiff";
 import { OutputStrategyFactory } from "./output";
 import { extractTargetFiles, filterPromptsByTarget, findPromptFiles, parsePromptFile, timestampAsString, type PromptMetadata } from "./util";
 
@@ -12,6 +13,7 @@ const commandPromptDirectoryMap: CommandPromptPathMap = new Map([
   ["codereviewCodeStandards", Config.getCodeReviewStandardPath],
   ["codereviewFunctional", Config.getCodeReviewFunctionalPath],
   ["codereviewNonFunctional", Config.getCodeReviewNonFunctionalPath],
+  ["codereviewDiff", Config.getCodeReviewDiffPath],
   ["reverseEngineering", Config.getReverseEngineeringPromptPath],
   ["drawDiagrams", Config.getDrawDiagramsPromptPath],
 ]);
@@ -71,6 +73,11 @@ export const chatHandler: vscode.ChatRequestHandler = async (request, context, s
     // ResponseStream をラップして、ファイルに保存するようにする
     stream = new FileChatResponseStreamWrapper(stream, makeChatFilePath(outputDirPath));
   }
+
+  if (command === "codereviewDiff") {
+    return processGitDiffReview(request, promptMetadata, request.model, token, stream);
+  }
+
   // ユーザの Chat Request 中で指定されたレビュー対象ファイルを取得する
   const targetFiles = await extractTargetFiles(request, stream);
   if (targetFiles.length > 0) {
@@ -85,6 +92,77 @@ export const chatHandler: vscode.ChatRequestHandler = async (request, context, s
 export function getPromptDirectory(command: string): string | undefined {
   const dir = commandPromptDirectoryMap.get(command)?.();
   return dir;
+}
+
+export async function processGitDiffReview(
+  request: vscode.ChatRequest,
+  promptMetadata: PromptMetadata[],
+  model: vscode.LanguageModelChat,
+  token: vscode.CancellationToken,
+  stream: vscode.ChatResponseStream,
+): Promise<void | vscode.ChatResult> {
+  const range = gitDiff.extractDiffRange(request.prompt, Config.getGitDiffDefaultRange());
+  let repo: gitDiff.GitRepository | undefined;
+  let diffFiles: gitDiff.GitDiffFile[];
+
+  try {
+    repo = await gitDiff.getGitRepository();
+    if (!repo) {
+      return createErrorResponse("No Git repository found in the current workspace.", stream);
+    }
+
+    diffFiles = await gitDiff.getDiffFiles(repo, range);
+  } catch (error) {
+    return createErrorResponse(`Failed to get Git diff for range ${range}: ${errorToMessage(error)}`, stream);
+  }
+
+  if (diffFiles.length === 0) {
+    stream.markdown(`No Git diff found for \`${range}\`.\n`);
+    return;
+  }
+
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? repo.rootUri.fsPath;
+  const processableFiles: Array<{ diffFile: gitDiff.GitDiffFile; applicablePrompts: PromptMetadata[] }> = [];
+  const skippedFiles: string[] = [];
+
+  for (const diffFile of diffFiles) {
+    if (diffFile.changeType === "deleted") {
+      skippedFiles.push(`${diffFile.relativePath} (deleted file has no new side)`);
+      continue;
+    }
+
+    if (!gitDiff.hasReviewableHunks(diffFile)) {
+      skippedFiles.push(`${diffFile.relativePath} (no reviewable hunks)`);
+      continue;
+    }
+
+    const applicablePrompts = filterPromptsByTarget(promptMetadata, diffFile.filePath, workspaceRoot);
+    if (applicablePrompts.length === 0) {
+      skippedFiles.push(`${diffFile.relativePath} (no matching prompts)`);
+      continue;
+    }
+
+    processableFiles.push({ diffFile, applicablePrompts });
+  }
+
+  if (processableFiles.length === 0) {
+    stream.markdown(`No reviewable Git diff files found for \`${range}\`.\n`);
+    outputSkippedDiffFiles(skippedFiles, stream);
+    return;
+  }
+
+  const strategy = OutputStrategyFactory.create(Config.getOutputMode());
+  let processedCount = 0;
+
+  stream.markdown(`Reviewing ${processableFiles.length} Git diff file(s) for \`${range}\`.\n\n`);
+  for (const { diffFile, applicablePrompts } of processableFiles) {
+    strategy.outputProgress(processedCount, processableFiles.length, stream);
+    stream.markdown(`Applying ${applicablePrompts.length} prompt(s) to diff ${diffFile.relativePath}\n`);
+    await processContent(gitDiff.formatDiffForReview(diffFile, range), diffFile.filePath, applicablePrompts, model, token, stream);
+    processedCount++;
+  }
+
+  outputSkippedDiffFiles(skippedFiles, stream);
 }
 
 /**
@@ -321,4 +399,23 @@ export function createErrorResponse(message: string, stream: vscode.ChatResponse
   console.debug(message);
   stream.markdown(message);
   return { errorDetails: { message } };
+}
+
+function outputSkippedDiffFiles(skippedFiles: string[], stream: vscode.ChatResponseStream): void {
+  if (skippedFiles.length === 0) {
+    return;
+  }
+
+  stream.markdown(`\nSkipped ${skippedFiles.length} Git diff file(s):\n`);
+  for (const skippedFile of skippedFiles) {
+    stream.markdown(`  - ${skippedFile}\n`);
+  }
+}
+
+function errorToMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,20 @@ export class Config {
   }
 
   /**
+   * Git差分レビュー用プロンプトディレクトリのパスを取得する
+   * 未設定の場合はコード規約レビュー用プロンプトを利用する
+   * @returns ディレクトリパス、または未定義
+   */
+  static getCodeReviewDiffPath(): string | undefined {
+    const diffPath = vscode.workspace.getConfiguration().get<string>("codeReview.diffPath");
+    if (diffPath) {
+      return diffPath;
+    }
+
+    return Config.getCodeReviewStandardPath();
+  }
+
+  /**
    * リバースエンジニアリング用プロンプト格納ディレクトリのパスを取得します。
    * @returns ディレクトリパス、または未定義
    */
@@ -104,5 +118,13 @@ export class Config {
    */
   static getOutputMode(): "chat-only" | "file-only" {
     return vscode.workspace.getConfiguration().get<"chat-only" | "file-only">("promptis.output.mode", "chat-only");
+  }
+
+  /**
+   * Git差分レビューで使用するデフォルトの差分範囲を取得します。
+   * @returns デフォルトのGit差分範囲
+   */
+  static getGitDiffDefaultRange(): string {
+    return vscode.workspace.getConfiguration().get<string>("promptis.git.defaultDiffRange", "origin/main...HEAD");
   }
 }

--- a/src/gitDiff.ts
+++ b/src/gitDiff.ts
@@ -1,0 +1,188 @@
+import path from "path";
+import * as vscode from "vscode";
+
+export const DEFAULT_GIT_DIFF_RANGE = "origin/main...HEAD";
+
+export type GitDiffChangeType = "added" | "modified" | "deleted" | "renamed";
+
+export interface GitDiffFile {
+  filePath: string;
+  relativePath: string;
+  diff: string;
+  changeType: GitDiffChangeType;
+  oldPath?: string;
+}
+
+export interface GitRepository {
+  rootUri: vscode.Uri;
+  diffWith(ref: string, path?: string): Promise<string>;
+}
+
+interface GitApi {
+  repositories: GitRepository[];
+  getRepository(uri: vscode.Uri): GitRepository | null;
+}
+
+interface GitExtension {
+  getAPI(version: number): GitApi;
+}
+
+export function extractDiffRange(prompt: string, defaultRange: string = DEFAULT_GIT_DIFF_RANGE): string {
+  const match = prompt.match(/#range:(?:"([^"]+)"|(\S+))/);
+  const range = match?.[1] ?? match?.[2];
+
+  if (!range || range.trim().length === 0) {
+    return defaultRange;
+  }
+
+  return range.trim();
+}
+
+export async function getGitRepository(): Promise<GitRepository | undefined> {
+  const extension = vscode.extensions.getExtension<GitExtension>("vscode.git");
+  if (!extension) {
+    return undefined;
+  }
+
+  const gitExtension = extension.isActive ? extension.exports : await extension.activate();
+  const api = gitExtension.getAPI(1);
+
+  const workspaceFolderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+  if (workspaceFolderUri) {
+    const workspaceRepository = api.getRepository(workspaceFolderUri);
+    if (workspaceRepository) {
+      return workspaceRepository;
+    }
+  }
+
+  return api.repositories[0];
+}
+
+export async function getDiffFiles(repo: GitRepository, range: string): Promise<GitDiffFile[]> {
+  const diffOutput = await repo.diffWith(range);
+  return parseUnifiedDiff(diffOutput, repo.rootUri.fsPath);
+}
+
+export function parseUnifiedDiff(diffOutput: string, repoRootPath: string): GitDiffFile[] {
+  if (diffOutput.trim().length === 0) {
+    return [];
+  }
+
+  return diffOutput
+    .split(/^diff --git /m)
+    .slice(1)
+    .map((chunk) => parseFileDiff(`diff --git ${chunk}`, repoRootPath))
+    .filter((result): result is GitDiffFile => result !== undefined);
+}
+
+export function hasReviewableHunks(diffFile: GitDiffFile): boolean {
+  return diffFile.diff.split(/\r?\n/).some((line) => line.startsWith("@@ "));
+}
+
+export function formatDiffForReview(diffFile: GitDiffFile, range: string): string {
+  const lines = [
+    "Review only the new side of this Git unified diff.",
+    "Focus on added or modified lines. Use deleted and context lines only to understand the change.",
+    `Diff range: ${range}`,
+    `File: ${diffFile.relativePath}`,
+    `Change type: ${diffFile.changeType}`,
+  ];
+
+  if (diffFile.oldPath) {
+    lines.push(`Old file: ${diffFile.oldPath}`);
+  }
+
+  lines.push("", "```diff", diffFile.diff.trimEnd(), "```");
+  return lines.join("\n");
+}
+
+function parseFileDiff(fileDiff: string, repoRootPath: string): GitDiffFile | undefined {
+  const lines = fileDiff.split(/\r?\n/);
+  const headerPaths = parseHeaderPaths(lines[0]);
+  const oldMarkerPath = parseMarkerPath(lines.find((line) => line.startsWith("--- ")));
+  const newMarkerPath = parseMarkerPath(lines.find((line) => line.startsWith("+++ ")));
+  const renameFrom = parseRenamePath(lines.find((line) => line.startsWith("rename from ")), "rename from ");
+  const renameTo = parseRenamePath(lines.find((line) => line.startsWith("rename to ")), "rename to ");
+
+  const oldPath = oldMarkerPath ?? renameFrom ?? headerPaths?.oldPath;
+  const newPath = newMarkerPath ?? renameTo ?? headerPaths?.newPath;
+  const relativePath = newPath ?? oldPath;
+
+  if (!relativePath) {
+    return undefined;
+  }
+
+  const changeType = detectChangeType(fileDiff, oldPath, newPath, renameFrom, renameTo);
+  const oldFilePath = oldPath && oldPath !== relativePath ? oldPath : undefined;
+
+  return {
+    filePath: path.join(repoRootPath, relativePath),
+    relativePath,
+    diff: fileDiff,
+    changeType,
+    oldPath: oldFilePath,
+  };
+}
+
+function parseHeaderPaths(header: string): { oldPath: string; newPath: string } | undefined {
+  const match = header.match(/^diff --git a\/(.+) b\/(.+)$/);
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    oldPath: match[1],
+    newPath: match[2],
+  };
+}
+
+function parseMarkerPath(line: string | undefined): string | undefined {
+  if (!line) {
+    return undefined;
+  }
+
+  const markerPath = line.slice(4).trim();
+  if (markerPath === "/dev/null") {
+    return undefined;
+  }
+
+  return removeDiffPrefix(markerPath);
+}
+
+function parseRenamePath(line: string | undefined, prefix: string): string | undefined {
+  if (!line) {
+    return undefined;
+  }
+
+  return line.slice(prefix.length).trim();
+}
+
+function removeDiffPrefix(diffPath: string): string {
+  if (diffPath.startsWith("a/") || diffPath.startsWith("b/")) {
+    return diffPath.slice(2);
+  }
+
+  return diffPath;
+}
+
+function detectChangeType(
+  fileDiff: string,
+  oldPath: string | undefined,
+  newPath: string | undefined,
+  renameFrom: string | undefined,
+  renameTo: string | undefined,
+): GitDiffChangeType {
+  if (fileDiff.includes("\nnew file mode ")) {
+    return "added";
+  }
+
+  if (fileDiff.includes("\ndeleted file mode ")) {
+    return "deleted";
+  }
+
+  if (renameFrom || renameTo || (oldPath && newPath && oldPath !== newPath)) {
+    return "renamed";
+  }
+
+  return "modified";
+}

--- a/src/test/chatHandler.test.ts
+++ b/src/test/chatHandler.test.ts
@@ -83,6 +83,11 @@ suite("chatHandler Test Suite", function () {
       assert.strictEqual(result, undefined);
     });
 
+    test("getPromptDirectory should support codereviewDiff command", function () {
+      const result = chatHandlerModule.getPromptDirectory("codereviewDiff");
+      assert.strictEqual(result, path.normalize(`${__dirname}/../../src/test/__tests__/`));
+    });
+
     test("chatHandler should return error if no command is specified", async function () {
       const request: vscode.ChatRequest = {
         command: "", // コマンドを指定しない

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -44,6 +44,21 @@ suite("Config Test Suite", () => {
       assert.strictEqual(result, "code/review/non-functional/path");
     });
 
+    test("should return the Git diff review path using Config class", function () {
+      const getStub = mockGetConfiguration().get as sinon.SinonStub;
+      getStub.withArgs("codeReview.diffPath").returns("code/review/diff/path");
+      const result = Config.getCodeReviewDiffPath();
+      assert.strictEqual(result, "code/review/diff/path");
+    });
+
+    test("should use code review standard path if Git diff review path is not configured", function () {
+      const getStub = mockGetConfiguration().get as sinon.SinonStub;
+      getStub.withArgs("codeReview.diffPath").returns(undefined);
+      getStub.withArgs("codeReview.codeStandardPath").returns("code/review/standard/path");
+      const result = Config.getCodeReviewDiffPath();
+      assert.strictEqual(result, "code/review/standard/path");
+    });
+
     test("should return the reverse engineering prompt path using Config class", function () {
       const getStub = mockGetConfiguration().get as sinon.SinonStub;
       getStub.withArgs("reverseEngineering.promptsPath").returns("reverse/engineering/prompts/path");
@@ -112,6 +127,20 @@ suite("Config Test Suite", () => {
       getStub.withArgs("promptis.output.mode", "chat-only").returns("chat-only");
       const result = Config.getOutputMode();
       assert.strictEqual(result, "chat-only");
+    });
+
+    test("should return the default Git diff range", function () {
+      const getStub = mockGetConfiguration().get as sinon.SinonStub;
+      getStub.withArgs("promptis.git.defaultDiffRange", "origin/main...HEAD").returns("origin/main...HEAD");
+      const result = Config.getGitDiffDefaultRange();
+      assert.strictEqual(result, "origin/main...HEAD");
+    });
+
+    test("should return configured Git diff range", function () {
+      const getStub = mockGetConfiguration().get as sinon.SinonStub;
+      getStub.withArgs("promptis.git.defaultDiffRange", "origin/main...HEAD").returns("origin/develop...HEAD");
+      const result = Config.getGitDiffDefaultRange();
+      assert.strictEqual(result, "origin/develop...HEAD");
     });
   });
 });

--- a/src/test/gitDiff.test.ts
+++ b/src/test/gitDiff.test.ts
@@ -1,0 +1,155 @@
+import * as assert from "assert";
+import path from "path";
+import * as vscode from "vscode";
+import {
+  extractDiffRange,
+  formatDiffForReview,
+  getDiffFiles,
+  hasReviewableHunks,
+  parseUnifiedDiff,
+  type GitRepository,
+} from "../gitDiff";
+
+suite("GitDiff Test Suite", function () {
+  suite("extractDiffRange Test Suite", function () {
+    test("should return default range when #range is not specified", function () {
+      const result = extractDiffRange("review this diff", "origin/main...HEAD");
+      assert.strictEqual(result, "origin/main...HEAD");
+    });
+
+    test("should extract unquoted #range value", function () {
+      const result = extractDiffRange("review #range:HEAD~3..HEAD", "origin/main...HEAD");
+      assert.strictEqual(result, "HEAD~3..HEAD");
+    });
+
+    test("should extract quoted #range value", function () {
+      const result = extractDiffRange('review #range:"origin/develop...HEAD"', "origin/main...HEAD");
+      assert.strictEqual(result, "origin/develop...HEAD");
+    });
+  });
+
+  suite("parseUnifiedDiff Test Suite", function () {
+    const repoRootPath = "/workspace/project";
+
+    test("should parse modified and added files from unified diff", function () {
+      const diffOutput = [
+        "diff --git a/src/app.ts b/src/app.ts",
+        "index 1111111..2222222 100644",
+        "--- a/src/app.ts",
+        "+++ b/src/app.ts",
+        "@@ -1,2 +1,2 @@",
+        "-const oldValue = 1;",
+        "+const newValue = 1;",
+        "diff --git a/src/new.ts b/src/new.ts",
+        "new file mode 100644",
+        "index 0000000..3333333",
+        "--- /dev/null",
+        "+++ b/src/new.ts",
+        "@@ -0,0 +1 @@",
+        "+export const created = true;",
+        "",
+      ].join("\n");
+
+      const result = parseUnifiedDiff(diffOutput, repoRootPath);
+
+      assert.strictEqual(result.length, 2);
+      assert.deepStrictEqual(
+        result.map((file) => ({ relativePath: file.relativePath, changeType: file.changeType })),
+        [
+          { relativePath: "src/app.ts", changeType: "modified" },
+          { relativePath: "src/new.ts", changeType: "added" },
+        ],
+      );
+      assert.strictEqual(result[0].filePath, path.join(repoRootPath, "src/app.ts"));
+    });
+
+    test("should parse deleted and renamed files", function () {
+      const diffOutput = [
+        "diff --git a/src/removed.ts b/src/removed.ts",
+        "deleted file mode 100644",
+        "index 1111111..0000000",
+        "--- a/src/removed.ts",
+        "+++ /dev/null",
+        "@@ -1 +0,0 @@",
+        "-export const removed = true;",
+        "diff --git a/src/old.ts b/src/new-name.ts",
+        "similarity index 88%",
+        "rename from src/old.ts",
+        "rename to src/new-name.ts",
+        "--- a/src/old.ts",
+        "+++ b/src/new-name.ts",
+        "@@ -1 +1 @@",
+        "-export const name = 'old';",
+        "+export const name = 'new';",
+        "",
+      ].join("\n");
+
+      const result = parseUnifiedDiff(diffOutput, repoRootPath);
+
+      assert.strictEqual(result.length, 2);
+      assert.strictEqual(result[0].relativePath, "src/removed.ts");
+      assert.strictEqual(result[0].changeType, "deleted");
+      assert.strictEqual(result[1].relativePath, "src/new-name.ts");
+      assert.strictEqual(result[1].changeType, "renamed");
+      assert.strictEqual(result[1].oldPath, "src/old.ts");
+    });
+
+    test("should return empty array for empty diff", function () {
+      const result = parseUnifiedDiff("", repoRootPath);
+      assert.deepStrictEqual(result, []);
+    });
+  });
+
+  suite("getDiffFiles Test Suite", function () {
+    test("should call VS Code Git repository diffWith by raw range", async function () {
+      const diffOutput = [
+        "diff --git a/src/app.ts b/src/app.ts",
+        "index 1111111..2222222 100644",
+        "--- a/src/app.ts",
+        "+++ b/src/app.ts",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+        "",
+      ].join("\n");
+      const repo = {
+        rootUri: vscode.Uri.file("/workspace/project"),
+        diffWith: async (range: string) => {
+          assert.strictEqual(range, "origin/main...HEAD");
+          return diffOutput;
+        },
+      } as GitRepository;
+
+      const result = await getDiffFiles(repo, "origin/main...HEAD");
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].relativePath, "src/app.ts");
+    });
+  });
+
+  suite("formatDiffForReview Test Suite", function () {
+    test("should format diff with range, file, change type, and unified diff", function () {
+      const diffFile = parseUnifiedDiff(
+        [
+          "diff --git a/src/app.ts b/src/app.ts",
+          "index 1111111..2222222 100644",
+          "--- a/src/app.ts",
+          "+++ b/src/app.ts",
+          "@@ -1 +1 @@",
+          "-old",
+          "+new",
+          "",
+        ].join("\n"),
+        "/workspace/project",
+      )[0];
+
+      const result = formatDiffForReview(diffFile, "origin/main...HEAD");
+
+      assert.match(result, /Diff range: origin\/main\.\.\.HEAD/);
+      assert.match(result, /File: src\/app\.ts/);
+      assert.match(result, /Change type: modified/);
+      assert.match(result, /```diff/);
+      assert.strictEqual(hasReviewableHunks(diffFile), true);
+    });
+  });
+});


### PR DESCRIPTION
# 概要
Git差分のみを対象にレビューできる `/codereviewDiff` コマンドを追加します。
Issue #112 で合意した Phase 1 範囲として、差分範囲指定と既存プロンプト実行フローへの統合を実装しました。

# 背景
既存のコードレビューはファイル全体を対象にするため、PRレビュー時に変更箇所以外もLLMへ送信され、処理時間とレビュー結果のノイズが増える課題がありました。

# 変更内容
- `package.json` に `/codereviewDiff` チャットコマンドを追加
- `codeReview.diffPath` 設定を追加し、未設定時は `codeReview.codeStandardPath` を利用
- `promptis.git.defaultDiffRange` 設定を追加し、既定値を `origin/main...HEAD` に設定
- VS Code Git Extension API（`vscode.git`）からGit差分を取得する `src/gitDiff.ts` を追加
- `#range:origin/develop...HEAD` / `#range:HEAD~3..HEAD` 形式の差分範囲指定に対応
- Unified diffをファイル単位で解析し、削除ファイルやレビュー対象ハンクのないファイルをスキップ
- 既存の `processContent` とプロンプトフィルタリングを再利用して差分レビューを実行
- `README.md` / `README-en.md` に利用方法と設定を追記
- Git差分解析、範囲抽出、設定取得、コマンド解決のテストを追加

# 影響範囲
- API: なし
- UI: `/codereviewDiff` チャットコマンドと `#range` 利用手順を追加
- DB: なし
- Infra: なし

# 動作確認
1. `npm ci` を実行
2. `npm run compile` を実行
3. `npm test` を実行
4. VS Code拡張テストで `146 passing` を確認

# テスト
- `src/test/gitDiff.test.ts` を追加し、差分範囲抽出、Unified diff解析、削除/リネーム判定、レビュー用フォーマットを検証
- `src/test/config.test.ts` に `codeReview.diffPath` と `promptis.git.defaultDiffRange` の検証を追加
- `src/test/chatHandler.test.ts` に `/codereviewDiff` のプロンプトディレクトリ解決を追加
- カバレッジへの定量影響は未算出

# リスク
- `vscode.git` の `diffWith` に渡すGit range解釈はVS Code Git拡張の実装に依存します。`origin/main...HEAD` と `HEAD~3..HEAD` の単体呼び出し経路を固定し、失敗時は範囲付きエラーメッセージを返すことで切り分け可能にしています。
- 大きな差分ではLLM送信量が増える可能性があります。Phase 1ではファイル単位のUnified diff送信に留め、チャンキングは今後の拡張対象とします。
